### PR TITLE
Adding Thredds & OpenDap input

### DIFF
--- a/core/src/main/java/org/apache/sdap/mudrod/main/MudrodConstants.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/main/MudrodConstants.java
@@ -59,6 +59,19 @@ public interface MudrodConstants {
   public static final String HTTP_TYPE = "raw.http";
 
   public static final String HTTP_LOG = "http";
+  
+  // ***
+  public static final String ACCESS_PREFIX = "mudrod.access.prefix";
+
+  public static final String ACCESS_LOG = "access";
+  
+  public static final String THREDDS_PREFIX = "mudrod.thredds.prefix";
+
+  public static final String THREDDS_LOG = "thredds";
+  
+  public static final String OPENDAP_PREFIX = "mudrod.opendap.prefix";
+
+  public static final String OPENDAP_LOG = "opendap";
 
   public static final String BASE_URL = "mudrod.base.url";
 

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ApacheAccessLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ApacheAccessLog.java
@@ -18,7 +18,6 @@ import com.google.gson.Gson;
 import org.apache.sdap.mudrod.main.MudrodConstants;
 import org.apache.sdap.mudrod.weblog.pre.CrawlerDetection;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -96,7 +95,7 @@ public class ApacheAccessLog extends WebLog implements Serializable {
       }
 
       ApacheAccessLog accesslog = new ApacheAccessLog();
-      accesslog.LogType = MudrodConstants.HTTP_LOG;
+      accesslog.LogType = MudrodConstants.ACCESS_LOG;
       accesslog.IP = matcher.group(1);
       accesslog.Request = matcher.group(5);
       accesslog.Response = matcher.group(6);

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/HttpLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/HttpLog.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sdap.mudrod.weblog.structure.log;
+
+import com.google.gson.Gson;
+
+import org.apache.sdap.mudrod.main.MudrodConstants;
+import org.apache.sdap.mudrod.weblog.pre.CrawlerDetection;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class represents an Http log line. See
+ * http://httpd.apache.org/docs/2.2/logs.html for more details.
+ */
+
+public class HttpLog extends WebLog implements Serializable {
+	
+	String Response;
+	String Referer;
+	String Browser;
+
+	@Override
+	public double getBytes() {
+	  return this.Bytes;
+	}
+
+	public String getBrowser() {
+	  return this.Browser;
+	}
+
+	public String getResponse() {
+	  return this.Response;
+	}
+
+	public String getReferer() {
+	  return this.Referer;
+	}
+
+	public HttpLog() {
+		  super();
+	}
+
+	public static String parseFromLogLine(String log, Properties props) throws ParseException {
+
+	  String logEntryPattern = "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})] \"(.+?)\" (\\d{3}) (\\d+|-) \"((?:[^\"]|\")+)\" \"([^\"]+)\"";
+	  final int numFields = 9;
+	  Pattern p = Pattern.compile(logEntryPattern);
+	  Matcher matcher;
+
+	  String lineJson = "{}";
+	  matcher = p.matcher(log);
+	  if (!matcher.matches() || numFields != matcher.groupCount()) {
+	    return lineJson;
+	  }
+
+	  String time = matcher.group(4);
+	  time = SwithtoNum(time);
+	  SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy:HH:mm:ss");
+	  Date date = formatter.parse(time);
+
+	  String bytes = matcher.group(7);
+
+	  if ("-".equals(bytes)) {
+	    bytes = "0";
+	  }
+
+	  String request = matcher.group(5).toLowerCase();
+	  String agent = matcher.group(9);
+	  
+	  // *** need to be modified
+	  CrawlerDetection crawlerDe = new CrawlerDetection(props);
+	  if (crawlerDe.checkKnownCrawler(agent)) {
+	    return lineJson;
+	  } else {
+
+	    String[] mimeTypes = props.getProperty(MudrodConstants.BLACK_LIST_REQUEST).split(",");
+	    for (String mimeType : mimeTypes) {
+	      if (request.contains(mimeType)) {
+	        return lineJson;
+	      }
+	    }
+
+	    HttpLog httpLog = new HttpLog();
+	    
+	    // *** need to be modified
+	    httpLog.LogType = MudrodConstants.HTTP_LOG;
+	    httpLog.IP = matcher.group(1);
+	    httpLog.Request = matcher.group(5);
+	    httpLog.Response = matcher.group(6);
+	    httpLog.Bytes = Double.parseDouble(bytes);
+	    httpLog.Referer = matcher.group(8);
+	    httpLog.Browser = matcher.group(9);
+	    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+	    httpLog.Time = df.format(date);
+
+	    Gson gson = new Gson();
+	    lineJson = gson.toJson(httpLog);
+
+	    return lineJson;
+	}
+	}
+
+	public static boolean checknull(WebLog s) {
+	  if (s == null) {
+	    return false;
+	  }
+	  return true;
+	}
+}

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/OpenDapLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/OpenDapLog.java
@@ -1,11 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.sdap.mudrod.weblog.structure.log;
 
+import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-public class OpenDapLog extends ApacheAccessLog {
+import org.apache.sdap.mudrod.main.MudrodConstants;
+import org.apache.sdap.mudrod.weblog.pre.CrawlerDetection;
 
-  public static String parseFromLogLine(String log, Properties props) {
-	return log;
+import com.google.gson.Gson;
 
-  }
+/**
+ * This class represents an Opendap log line. See
+ * http://httpd.apache.org/docs/2.2/logs.html for more details.
+ */
+
+public class OpenDapLog extends HttpLog implements Serializable {
+
+	public OpenDapLog() {
+		super();
+	}
+	
+	public static String parseFromLogLine(String log, Properties props) throws ParseException {
+		String logEntryPattern = "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})] \"(.+?)\" (\\d{3}) (\\d+|-) \"((?:[^\"]|\")+)\" \"([^\"]+)\"";
+		final int numFields = 9;
+		Pattern p = Pattern.compile(logEntryPattern);
+		Matcher matcher;
+
+		String lineJson = "{}";
+		matcher = p.matcher(log);
+		if (!matcher.matches() || numFields != matcher.groupCount()) {
+			return lineJson;
+		}
+
+		String time = matcher.group(4);
+		time = SwithtoNum(time);
+		SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy:HH:mm:ss");
+		Date date = formatter.parse(time);
+
+		String bytes = matcher.group(7);
+
+		if ("-".equals(bytes)) {
+			bytes = "0";
+		}
+
+		String request = matcher.group(5).toLowerCase();
+		String agent = matcher.group(9);
+
+		// *** need to be modified
+		CrawlerDetection crawlerDe = new CrawlerDetection(props);
+		if (crawlerDe.checkKnownCrawler(agent)) {
+			return lineJson;
+		} else {
+
+			String[] mimeTypes = props.getProperty(MudrodConstants.BLACK_LIST_REQUEST).split(",");
+			for (String mimeType : mimeTypes) {
+				if (request.contains(mimeType)) {
+					return lineJson;
+				}
+			}
+
+			OpenDapLog OpendapLog = new OpenDapLog();
+
+			// *** need to be modified
+			OpendapLog.LogType = MudrodConstants.OPENDAP_LOG;
+			OpendapLog.IP = matcher.group(1);
+			OpendapLog.Request = matcher.group(5);
+			OpendapLog.Response = matcher.group(6);
+			OpendapLog.Bytes = Double.parseDouble(bytes);
+			OpendapLog.Referer = matcher.group(8);
+			OpendapLog.Browser = matcher.group(9);
+			SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+			OpendapLog.Time = df.format(date);
+
+			Gson gson = new Gson();
+			lineJson = gson.toJson(OpendapLog);
+
+			return lineJson;
+
+		}
+	}
 }

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/OpenDapLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/OpenDapLog.java
@@ -1,8 +1,11 @@
 package org.apache.sdap.mudrod.weblog.structure.log;
 
-public class OpendapLog extends ApacheAccessLog {
+import java.util.Properties;
 
-  public static String parseFromLogLine(String log, Properties props) throws ParseException {
+public class OpenDapLog extends ApacheAccessLog {
+
+  public static String parseFromLogLine(String log, Properties props) {
+	return log;
 
   }
 }

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ThreddsLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ThreddsLog.java
@@ -1,11 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class represents an Thredds log line. See
+ * http://httpd.apache.org/docs/2.2/logs.html for more details.
+ */
+
 package org.apache.sdap.mudrod.weblog.structure.log;
 
+import java.text.ParseException;
 import java.util.Properties;
 
-public class ThreddsLog extends ApacheAccessLog {
-  
-  public static String parseFromLogLine(String log, Properties props) {
-	return log;
+import com.google.gson.Gson;
 
-  }
+import org.apache.sdap.mudrod.main.MudrodConstants;
+import org.apache.sdap.mudrod.weblog.pre.CrawlerDetection;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ThreddsLog extends HttpLog implements Serializable {
+
+	public ThreddsLog() {
+		super();
+	}
+	
+	public static String parseFromLogLine(String log, Properties props) throws ParseException {
+		String logEntryPattern = "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})] \"(.+?)\" (\\d{3}) (\\d+|-) \"((?:[^\"]|\")+)\" \"([^\"]+)\"";
+		final int numFields = 9;
+		Pattern p = Pattern.compile(logEntryPattern);
+		Matcher matcher;
+
+		String lineJson = "{}";
+		matcher = p.matcher(log);
+		if (!matcher.matches() || numFields != matcher.groupCount()) {
+			return lineJson;
+		}
+
+		String time = matcher.group(4);
+		time = SwithtoNum(time);
+		SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy:HH:mm:ss");
+		Date date = formatter.parse(time);
+
+		String bytes = matcher.group(7);
+
+		if ("-".equals(bytes)) {
+			bytes = "0";
+		}
+
+		String request = matcher.group(5).toLowerCase();
+		String agent = matcher.group(9);
+
+		// *** need to be modified
+		CrawlerDetection crawlerDe = new CrawlerDetection(props);
+		if (crawlerDe.checkKnownCrawler(agent)) {
+			return lineJson;
+		} else {
+
+			String[] mimeTypes = props.getProperty(MudrodConstants.BLACK_LIST_REQUEST).split(",");
+			for (String mimeType : mimeTypes) {
+				if (request.contains(mimeType)) {
+					return lineJson;
+				}
+			}
+
+			ThreddsLog threddsLog = new ThreddsLog();
+
+			// *** need to be modified
+			threddsLog.LogType = MudrodConstants.THREDDS_LOG;
+			threddsLog.IP = matcher.group(1);
+			threddsLog.Request = matcher.group(5);
+			threddsLog.Response = matcher.group(6);
+			threddsLog.Bytes = Double.parseDouble(bytes);
+			threddsLog.Referer = matcher.group(8);
+			threddsLog.Browser = matcher.group(9);
+			SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+			threddsLog.Time = df.format(date);
+
+			Gson gson = new Gson();
+			lineJson = gson.toJson(threddsLog);
+
+			return lineJson;
+
+		}
+	}
 }

--- a/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ThreddsLog.java
+++ b/core/src/main/java/org/apache/sdap/mudrod/weblog/structure/log/ThreddsLog.java
@@ -1,8 +1,11 @@
 package org.apache.sdap.mudrod.weblog.structure.log;
 
+import java.util.Properties;
+
 public class ThreddsLog extends ApacheAccessLog {
   
-  public static String parseFromLogLine(String log, Properties props) throws ParseException {
+  public static String parseFromLogLine(String log, Properties props) {
+	return log;
 
   }
 }


### PR DESCRIPTION
Adding Thredds & OpenDap input. Now input files have two main types: ftp and http, and there are three sub-types of http log files: access log, Thredds log, and OpenDap log.